### PR TITLE
[gradle] Fixed a dependancy name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compile 'com.github.owncloud:android-library:oc-android-library-0.9.8'
     compile 'commons-io:commons-io:2.4'
 
-    compile('com.afollestad.material-dialogs:core:0.8.1.0@aar') {
+    compile('com.github.afollestad.material-dialogs:core:0.8.1.0@aar') {
         transitive = true
     }
 }


### PR DESCRIPTION
This fixes an "`Error:Could not find com.afollestad.material-dialogs:core:0.8.1.0.`" when building from Android Studio.

By the way, it looks like this dependancy is now at version 2.0.0-rc5 (see https://github.com/afollestad/material-dialogs). Just for fun, I tried to set this version in `build.gradle`. Since it gave me the following error, I am not sure this would even improve MyOwnNotes, and I am quite new to Android apps after all, I gave up. Maybe this would be interesting? I'll let you choose.
```
Could not find androidx.appcompat:appcompat:1.0.2.
Required by:
    MyOwnNotes:app:unspecified > com.github.afollestad.material-dialogs:core:2.0.0-rc5
```

Thanks for MyOwnNotes anyway